### PR TITLE
Pagination - remove the limit on the number of pages shown

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -5,6 +5,7 @@ identefier: marketing-index
 paginate:
   collection: posts
   per_page: 8
+  limit: false
 ---
 
 <main class="home">

--- a/blog/nursing/index.html
+++ b/blog/nursing/index.html
@@ -6,6 +6,7 @@ paginate:
   collection: nursing-posts
   per_page: 8
   reversed: true
+  limit: false
 ---
 
 <main class="home">

--- a/blog/tutor/index.html
+++ b/blog/tutor/index.html
@@ -6,6 +6,7 @@ paginate:
   collection: tutor-posts
   per_page: 8
   reversed: true
+  limit: false
 ---
 
 <main class="home">


### PR DESCRIPTION
## Why?

The blog index pages were only limited to showing 5 pages in the paginator.
https://github.com/octopress/paginate#configuration

The gem defaults to 5. Setting a limit of false, means there is no limit.

Right now, this would put the blog at 14 pages. We may need to explore alternatives once this number gets too high and there are too many pages appearing in the pagination links.

![image](https://user-images.githubusercontent.com/1131194/79235399-2a83cf00-7e31-11ea-972c-cd6af97d0d28.png)

## How to verify

Simply [run this branch locally](https://github.com/wyzant-dev/wyzant-siteleaf-cms#site-setup) and confirm that there is no longer a 5 page limit on each of the index pages.

http://localhost:4000/blog/ (14 pages)
http://localhost:4000/blog/tutor/ (there is only 5 pages of content)
http://localhost:4000/blog/nursing/ (only 1 page of content)

